### PR TITLE
Updated News API

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,17 +1,17 @@
-var APIKey = '401b9958d4b04c9eb9f4b7313ad0b743'
+$(document).ready(function(){
+
+var APIKey = 'Y7bWWVONOPeRUHMryrKxY4TiGIWIKQMQ'
 //var country = $("").val().trim();
-var queryURL = "http://newsapi.org/v2/top-headlines?country=us&category=technology&apiKey=" + APIKey;
-
+var queryURL = "https://api.nytimes.com/svc/topstories/v2/technology.json?api-key=" + APIKey;
+console.log(queryURL)
 $.ajax({
-    url: queryURL,
+    url:queryURL,
     method: "GET"
-}).then( function(response){
-    console.log(response)
-    // Set a variable to the title of the article
-    var title = respone.articles.title;
-
-    var source = response.articles.source.name;
-    var description = response.articles.description;
-    var url = response.articles.url;
-    //$('.article-title').text(title)
-});
+}).then(function(response) {
+    console.log(response);
+    var title = response.results[3].title
+    var description = response.results[3].abstract
+    var author = response.results[3].byline
+    var articleURL = response.results[3].url
+})
+})


### PR DESCRIPTION
Switched News API from US News to New York Times do to a CORS issue.